### PR TITLE
Skilltester Update

### DIFF
--- a/EngineHacks/SkillSystem_FE8/EngineHacks/Necessary/CalcLoops/PreBattleCalcLoop/PreBattleCalcLoop.event
+++ b/EngineHacks/SkillSystem_FE8/EngineHacks/Necessary/CalcLoops/PreBattleCalcLoop/PreBattleCalcLoop.event
@@ -18,9 +18,9 @@ POIN BtlLoopList
 
 ALIGN 4
 BtlLoopList:
+POIN InitializePreBattleLoop //Must go before aura skills
 POIN SetEquipmentAttributes
 POIN BC_DefRes BC_Power BC_ASpd BC_Hit BC_Avo BC_Crit BC_Support BC_WRank BC_Status //these are the existing battle calculation routines
-POIN InitializePreBattleLoop //Must go before aura skills
 POIN Lull //This is effectively a stat modifier routine, so it has to go first
 POIN BreakerCheck MageSlayer
 //POIN DefendingCheck

--- a/EngineHacks/SkillSystem_FE8/EngineHacks/Necessary/CalcLoops/WeaponUsabilityCalcLoop/WeaponUsabilityCalcLoop.event
+++ b/EngineHacks/SkillSystem_FE8/EngineHacks/Necessary/CalcLoops/WeaponUsabilityCalcLoop/WeaponUsabilityCalcLoop.event
@@ -26,7 +26,7 @@ ALIGN 4
 DoesUnitHaveWRank: //because of how it works, this both needs to be in the external calc loop and contain lumina/shadowgift
 #incbin "DoesUnitHaveWRank.dmp"
 POIN ItemTable
-POIN CheckSkillBuffer	//changed to skilltester2 to avoid indirect recursion (endlessly looping routine calls)
+POIN SkillTester	//changed to skilltester2 to avoid indirect recursion (endlessly looping routine calls)
 WORD ShadowgiftID
 WORD LuminaID
 WORD SHADOWGIFT_VIA_STAFF_RANK

--- a/EngineHacks/SkillSystem_FE8/EngineHacks/SkillSystem/Internals/NewSkillTester/Doc.md
+++ b/EngineHacks/SkillSystem_FE8/EngineHacks/SkillSystem/Internals/NewSkillTester/Doc.md
@@ -1,13 +1,15 @@
 ## Structs
-SkillBuffer:
+
+### SkillBuffer
 ```c
 struct SkillBuffer {
 /*00*/  u8 lastUnitChecked;
-/*01*/  u8 skills[11];
+/*01*/  bool isLocked;
+/*02*/  u8 skills[11];
 };
 ```
 
-AuraSkillBuffer:
+### AuraSkillBuffer
 ```c
 struct AuraSkillBuffer {
 /*00*/  u8 skillID;
@@ -18,10 +20,19 @@ struct AuraSkillBuffer {
 
 ## Functions
 
-### IsSkillInBuffer (SkillBuffer* buffer, u8 skillID)
+### IsSkillInBuffer
+```c
+bool IsSkillInBuffer(SkillBuffer* buffer, u8 skillID);
+```
+
 Loops through a given buffer to find the given skillID.  
 
-### NihilTester (Unit* unit, u8 skillID)
+
+### NihilTester
+```c
+bool NihilTester(Unit* unit, u8 skillID);
+```
+
 Checks if unit's opponent has Nihil and if the skill in question is negated by it.  
 Negated skills are found by indexing `NegatedSkills` by skillID.  
 
@@ -31,47 +42,50 @@ Negated skills are found by indexing `NegatedSkills` by skillID.
 Returns true if opponent has Nihil and skillID is negated.  
 Returns false otherwise.  
 
-### MakeSkillBuffer (Unit* unit, SkillBuffer* buffer)
+
+### MakeSkillBuffer
+```c
+SkillBuffer* MakeSkillBuffer(Unit* unit, SkillBuffer* buffer);
+```
+
 Checks a unit for skills, stores found skills in the given buffer, then returns that buffer's address.  
-If the unit is in battle, the equipped weapon data is gotten from the battle unit struct.  
-Stores the RAM unitID of the last unit checked in `SkillBuffer.lastUnitChecked` for future reference.  
-
-Returns the `SkillBuffer` pointer passed to it.  
+While doing weapon skill checks, sets `isLocked` bool on `buffer`.  
+Stores the unit index of the last unit checked in `SkillBuffer.lastUnitChecked` for future reference.  
 
 
-### MakeAuraSkillBuffer (Unit* unit)
-For each alive, deployed unit, calls `MakeSkillBuffer` and loops through the returned buffer to find aura skills.  
+### MakeAuraSkillBuffer
+```c
+AuraSkillBuffer* MakeAuraSkillBuffer(Unit* unit);
+```
+For each alive, deployed unit, calls [MakeSkillBuffer](#MakeSkillBuffer) and loops through the returned buffer to find aura skills.  
 For each skill in the buffer, `AuraSkillTable` is referenced by skillID to decide if the skill is an aura skill or not.  
 If an aura skill is found, a new entry in `AuraSkillBuffer` is made to save relevant information on the skill holder.  
-
-Returns a pointer to `AuraSkillBuffer`.  
 
 `AuraSkillTable` can be found in  
 `Root/EngineHacks/Necessary/CalcLoops/PreBattleCalcLoop/PreBattleCalcLoop.event`  
 
 The maximum number of `AuraSkillBuffer` entries can be set in `EngineHacks/SkillSystem/Internals/Skillsystem.event`.
 
-`MakeAuraSkillBuffer` can be called directly from any calcloop.  
+[MakeAuraSkillBuffer](#MakeAuraSkillBuffer) can be called directly from any calcloop.  
 
-### SkillTester (Unit* unit, int skillID)
+
+### SkillTester
+```c
+bool SkillTester(Unit* unit, int skillID);
+```
 Checks if unit has the given skill.  
-If the unit is the defender, the defender skill buffer is used.    
-If a different unit was checked last time, a new skill buffer is made  
+If a different unit was checked last time, a new skill buffer is made.
+If the `isLocked` bool is set, [SkillTester](#SkillTester) will not create a new skill buffer.  
 If the skill is found, a check for Nihil is done on the opponent.  
 
 Returns true if a match is found or skillID is 0.  
 Returns false if no match is found, skillID is 255 or skill is negated by nihil.  
 
 
-### CheckSkillBuffer (Unit* unit, int skillID)
-Called by the weapon usability loop to check the skill buffer in progress for a specified skill.  
-Used in order to prevent an infinite loop of `SkillTester` -> `CanUnitUseItem` -> `SkillTester`  
-
-Returns true if a match is found or skillID is 0.  
-Returns false if no match is found or skillID is 255.  
-
-
-### NewAuraSkillCheck (Unit* unit, int skillID, int allyOption, int maxRange)
+### NewAuraSkillCheck
+```c
+bool NewAuraSkillCheck(Unit* unit, int skillID, int allyOption, int maxRange);
+```
 Loops through the AuraSkillBuffer to find a matching skill holder who matches the specified requirements.  
 
 allyOption options are:
@@ -91,15 +105,21 @@ Returns true if a match is found or skillID is 0.
 Returns false if no match is found or skillID is 255.  
 
 
-### InitializePreBattleLoop(Unit* attacker, Unit* defender)
-Calls `AuraSkillBuffer` and `MakeSkillBuffer` for the attacker. If a real battle is happening, it calls `MakeSkillBuffer` for the defender as well.  
+### InitializePreBattleLoop
+```c
+void InitializePreBattleLoop(Unit* unit, Unit* opponent);
+```
+Calls `AuraSkillBuffer` and [MakeSkillBuffer](#MakeSkillBuffer) for `unit`.
+If a real battle is happening, it calls [MakeSkillBuffer](#MakeSkillBuffer) for `opponent` as well.  
 
-This function is used to initialize the PreBattle loop and not have to rely on MSG calling `SkillTester` on the defender.  
+This function is used to initialize the PreBattle loop and prepare `opponent` for Nihil checks.  
 
-Does not return a value.
 
-### GetUnitsInRange (Unit* unit, int allyOption, int range)
-Loops through each unit and checks if they meet the given requirements, and if so, their RAM unitID gets added to the `UnitRangeBuffer`.  
+### GetUnitsInRange
+```c
+u8* GetUnitsInRange(Unit* unit, int allyOption, int range);
+```
+Searches a `range` tile radius around `unit`. Each unit matching the criteria found gets their unit index gets added to the `UnitRangeBuffer`.  
 
 allyOption options are:
 ```
@@ -119,7 +139,7 @@ Returns 0 if no matching units are found.
 
 
 ## Limitations
-`NewAuraSkillCheck` only works if `MakeAuraSkillBuffer` was called prior for that unit and no units have moved since then.  
+[NewAuraSkillCheck](#NewAuraSkillCheck) only works if [MakeAuraSkillBuffer](#MakeAuraSkillBuffer) was called prior for that unit and no units have moved since then.  
 Ideally, it should be used at the beginning of calcloops.  
 
 If a function that's not in a calcloop needs to find an aura skill, use the old `AuraSkillCheck` function.  
@@ -128,6 +148,6 @@ If a function that's not in a calcloop needs to find an aura skill, use the old 
 ## New Conventions
 When adding or removing an aura skill, `AuraSkillTable` must be edited accordingly.  
 
-If a function needs to find an aura skill, use `NewAuraSkillCheck` or `AuraSkillCheck`.  
+If a function needs to find an aura skill, use [NewAuraSkillCheck](#NewAuraSkillCheck) or `AuraSkillCheck`.  
 
 If a function needs a list of units within a certain range, use `GetUnitsInRange`.  

--- a/EngineHacks/SkillSystem_FE8/EngineHacks/SkillSystem/Internals/NewSkillTester/_src/SkillTester.c
+++ b/EngineHacks/SkillSystem_FE8/EngineHacks/SkillSystem/Internals/NewSkillTester/_src/SkillTester.c
@@ -123,7 +123,7 @@ SkillBuffer* MakeSkillBuffer(Unit* unit, SkillBuffer* buffer) {
 
 //Creates an aura skill buffer with skill coordinates relative to a unit
 AuraSkillBuffer* MakeAuraSkillBuffer(Unit* unit) {
-    SkillBuffer* buffer = gGenericSkillBuffer;
+    SkillBuffer* buffer = gAttackerSkillBuffer;
     u8 count = 0;
     u8 distance = 0;
     u8* unitsInRange = GetUnitsInRange(unit, 4, 3);
@@ -179,13 +179,8 @@ bool SkillTester(Unit* unit, u8 skillID) {
     //Default to the attacker buffer
     SkillBuffer* buffer = gAttackerSkillBuffer;
 
-    //If unit is the defender, use the defender buffer
-    if (index == gBattleTarget.unit.index && IsBattleReal()) {
-        buffer = gDefenderSkillBuffer;
-    }
-
     if (index != buffer->lastUnitChecked && !buffer->isLocked) {
-        MakeSkillBuffer(unit, buffer);
+        MakeSkillBuffer(unit, gAttackerSkillBuffer);
     }
 
     //Check if matching skill is in buffer
@@ -249,6 +244,7 @@ void InitializePreBattleLoop(Unit* attacker) {
     MakeSkillBuffer(attacker, gAttackerSkillBuffer);
     gDefenderSkillBuffer->lastUnitChecked = 0;
 
+    //Make defender skill buffer for Nihil to reference
     if (IsBattleReal()) {
         MakeSkillBuffer(&gBattleTarget.unit, gDefenderSkillBuffer);
     }

--- a/EngineHacks/SkillSystem_FE8/EngineHacks/SkillSystem/Internals/NewSkillTester/_src/SkillTester.c
+++ b/EngineHacks/SkillSystem_FE8/EngineHacks/SkillSystem/Internals/NewSkillTester/_src/SkillTester.c
@@ -50,6 +50,7 @@ SkillBuffer* MakeSkillBuffer(Unit* unit, SkillBuffer* buffer) {
     int unitNum = unit->pCharacterData->number;
     int count = 0, temp = 0;
     buffer->lastUnitChecked = unit->index;
+    buffer->isLocked = FALSE;
 
     //Personal skill
     temp = PersonalSkillTable[unitNum].skillID;
@@ -105,7 +106,9 @@ SkillBuffer* MakeSkillBuffer(Unit* unit, SkillBuffer* buffer) {
     }
 
     //Equipped weapon skill
+    buffer->isLocked = TRUE;
     temp = GetItemData(GetUnitEquippedWeapon(unit) & 0xFF)->skill;
+    buffer->isLocked = FALSE;
 
     //Check if equipped weapon skill is valid
     if (IsSkillIDValid(temp)) {
@@ -165,22 +168,6 @@ AuraSkillBuffer* MakeAuraSkillBuffer(Unit* unit) {
     return gAuraSkillBuffer;
 }
 
-//Checks for skills in an in progress buffer
-//Used by the weapon usability calc loop
-bool CheckSkillBuffer(Unit* unit, u8 skillID) {
-    if (skillID == 0)   {return TRUE;}
-    if (skillID == 255) {return FALSE;}
-
-    SkillBuffer* buffer = gAttackerSkillBuffer;
-
-    //lastUnitChecked is already set, so no need for extra checks
-    if (unit->index == gDefenderSkillBuffer->lastUnitChecked) {
-        buffer = gDefenderSkillBuffer;
-    }
-
-    return IsSkillInBuffer(buffer, skillID);
-}
-
 //Checks unit for a given skill.
 //If the unit tested is the same as last time, uses the previous skill buffer
 bool SkillTester(Unit* unit, u8 skillID) {
@@ -197,7 +184,7 @@ bool SkillTester(Unit* unit, u8 skillID) {
         buffer = gDefenderSkillBuffer;
     }
 
-    if (index != buffer->lastUnitChecked) {
+    if (index != buffer->lastUnitChecked && !buffer->isLocked) {
         MakeSkillBuffer(unit, buffer);
     }
 

--- a/EngineHacks/SkillSystem_FE8/EngineHacks/SkillSystem/Internals/NewSkillTester/_src/SkillTester.c
+++ b/EngineHacks/SkillSystem_FE8/EngineHacks/SkillSystem/Internals/NewSkillTester/_src/SkillTester.c
@@ -102,6 +102,8 @@ SkillBuffer* MakeSkillBuffer(Unit* unit, SkillBuffer* buffer) {
     }
 
     //Equipped weapon skill
+    //Setting isLocked to true so SkillTester won't call this function.
+    //This is to prevent a SkillTester -> MakeSkillBuffer -> GetUnitEquippedWeapon -> CanUnitUseWeapon -> SkillTester loop.
     buffer->isLocked = TRUE;
     temp = GetItemData(GetUnitEquippedWeapon(unit) & 0xFF)->skill;
     buffer->isLocked = FALSE;
@@ -235,9 +237,9 @@ bool SkillAdder(Unit* unit, int skillID) {
 }
 
 //Prepares for prebattle calc loop
-void InitializePreBattleLoop(Unit* attacker, Unit* opponent) {
-    MakeAuraSkillBuffer(attacker);
-    MakeSkillBuffer(attacker, gAttackerSkillBuffer);
+void InitializePreBattleLoop(Unit* unit, Unit* opponent) {
+    MakeAuraSkillBuffer(unit);
+    MakeSkillBuffer(unit, gAttackerSkillBuffer);
 
     //Make defender skill buffer for Nihil to reference
     if (IsBattleReal()) {

--- a/EngineHacks/SkillSystem_FE8/EngineHacks/SkillSystem/Internals/NewSkillTester/_src/SkillTester.h
+++ b/EngineHacks/SkillSystem_FE8/EngineHacks/SkillSystem/Internals/NewSkillTester/_src/SkillTester.h
@@ -36,7 +36,7 @@ struct AuraSkillBuffer {
 extern struct BWLData gBWLDataArray[];
 
 extern SkillBuffer gAttackerSkillBuffer[];
-extern SkillBuffer gDefenderSkillBuffer[];
+extern SkillBuffer gOpponentSkillBuffer[];
 extern SkillBuffer gGenericSkillBuffer[];
 extern AuraSkillBuffer gAuraSkillBuffer[];
 extern u8 gTempSkillBuffer[];

--- a/EngineHacks/SkillSystem_FE8/EngineHacks/SkillSystem/Internals/NewSkillTester/_src/SkillTester.h
+++ b/EngineHacks/SkillSystem_FE8/EngineHacks/SkillSystem/Internals/NewSkillTester/_src/SkillTester.h
@@ -17,7 +17,8 @@ extern u8 GetEquipmentSkill(Unit* unit);
 
 struct SkillBuffer {
 /*00*/  u8 lastUnitChecked;
-/*01*/  u8 skills[12];
+/*01*/  bool isLocked; //Lets SkillTester know to not call MakeSkillBuffer and only reference what's in the skill buffer
+/*02*/  u8 skills[12];
 };
 
 struct BWLData {
@@ -33,6 +34,11 @@ struct AuraSkillBuffer {
 };
 
 extern struct BWLData gBWLDataArray[];
+
+enum MakeSkillBufferOptions {
+    DO_NOT_CHECK_WEAPON = 0,
+    CHECK_WEAPON        = 1,
+};
 
 extern SkillBuffer gAttackerSkillBuffer[];
 extern SkillBuffer gDefenderSkillBuffer[];

--- a/EngineHacks/SkillSystem_FE8/EngineHacks/SkillSystem/Internals/NewSkillTester/_src/SkillTester.h
+++ b/EngineHacks/SkillSystem_FE8/EngineHacks/SkillSystem/Internals/NewSkillTester/_src/SkillTester.h
@@ -35,11 +35,6 @@ struct AuraSkillBuffer {
 
 extern struct BWLData gBWLDataArray[];
 
-enum MakeSkillBufferOptions {
-    DO_NOT_CHECK_WEAPON = 0,
-    CHECK_WEAPON        = 1,
-};
-
 extern SkillBuffer gAttackerSkillBuffer[];
 extern SkillBuffer gDefenderSkillBuffer[];
 extern SkillBuffer gGenericSkillBuffer[];

--- a/EngineHacks/SkillSystem_FE8/EngineHacks/SkillSystem/Internals/NewSkillTester/reference/SkillsRef.s
+++ b/EngineHacks/SkillSystem_FE8/EngineHacks/SkillSystem/Internals/NewSkillTester/reference/SkillsRef.s
@@ -18,7 +18,7 @@ SET_FUNC __aeabi_idivmod, __modsi3
 SET_FUNC sub_8004B0C, 0x8004B0D
 
 SET_DATA gAttackerSkillBuffer, 0x02026BB0
-SET_DATA gDefenderSkillBuffer, 0x02026C00
+SET_DATA gOpponentSkillBuffer, 0x02026C00
 SET_DATA gTempSkillBuffer, 0x02026B90
 SET_DATA gAuraSkillBuffer, 0x02027200
 SET_DATA gUnitRangeBuffer, 0x0202764C

--- a/EngineHacks/SkillSystem_FE8/EngineHacks/SkillSystem/Skills/WeaponUsabilitySkills/SkillLockedUsability.c
+++ b/EngineHacks/SkillSystem_FE8/EngineHacks/SkillSystem/Skills/WeaponUsabilitySkills/SkillLockedUsability.c
@@ -2,13 +2,13 @@
 
 #define ITEM_ID_SHIV        0x16
 
-extern bool CheckSkillBuffer(Unit* unit, int skillID);
+extern bool SkillTester(Unit* unit, int skillID);
 
 extern u8 gCunningID;
 
 bool ShivUsabilityCheck(Unit* unit, u16 item, u8 rank) {
     if (GetItemIndex(item) == ITEM_ID_SHIV) {
-        if (CheckSkillBuffer(unit, gCunningID)) {
+        if (SkillTester(unit, gCunningID)) {
             return TRUE;
         }
         else {

--- a/EngineHacks/SkillSystem_FE8/EngineHacks/SkillSystem/Skills/WeaponUsabilitySkills/WeaponUsabilitySkills.event
+++ b/EngineHacks/SkillSystem_FE8/EngineHacks/SkillSystem/Skills/WeaponUsabilitySkills/WeaponUsabilitySkills.event
@@ -2,7 +2,7 @@
 ALIGN 4
 Shadowgift: //Also includes Lumina
 #incbin "Shadowgift/shadowgift.dmp"
-POIN CheckSkillBuffer
+POIN SkillTester
 WORD ShadowgiftID
 WORD LuminaID
 WORD SHADOWGIFT_VIA_STAFF_RANK
@@ -12,7 +12,7 @@ POIN ItemTable
 ALIGN 4
 Amische:
 #incbin "Amische/Amische.dmp"
-POIN CheckSkillBuffer
+POIN SkillTester
 WORD AmischeID
 POIN IronWeaponsList
 

--- a/Tools/FE-CLib/reference/FE8U-ControRef.s
+++ b/Tools/FE-CLib/reference/FE8U-ControRef.s
@@ -19,7 +19,7 @@ SET_FUNC __aeabi_idivmod, __modsi3
 SET_FUNC sub_8004B0C, 0x8004B0D
 
 SET_DATA gAttackerSkillBuffer, 0x02026BC0
-SET_DATA gDefenderSkillBuffer, 0x02026C00
+SET_DATA gOpponentSkillBuffer, 0x02026C00
 SET_DATA gGenericSkillBuffer, 0x03003770
 SET_DATA gTempSkillBuffer, 0x02026B90
 SET_DATA gAuraSkillBuffer, 0x02027200

--- a/Tools/FE-CLib/reference/FE8U-ControRef.s
+++ b/Tools/FE-CLib/reference/FE8U-ControRef.s
@@ -18,7 +18,7 @@ SET_FUNC __aeabi_idivmod, __modsi3
 
 SET_FUNC sub_8004B0C, 0x8004B0D
 
-SET_DATA gAttackerSkillBuffer, 0x02026BB0
+SET_DATA gAttackerSkillBuffer, 0x02026BC0
 SET_DATA gDefenderSkillBuffer, 0x02026C00
 SET_DATA gGenericSkillBuffer, 0x03003770
 SET_DATA gTempSkillBuffer, 0x02026B90

--- a/Tools/FE-CLib/reference/FE8U-ControRef.s
+++ b/Tools/FE-CLib/reference/FE8U-ControRef.s
@@ -18,10 +18,10 @@ SET_FUNC __aeabi_idivmod, __modsi3
 
 SET_FUNC sub_8004B0C, 0x8004B0D
 
-SET_DATA gAttackerSkillBuffer, 0x03003750
-SET_DATA gDefenderSkillBuffer, 0x03003760
+SET_DATA gAttackerSkillBuffer, 0x02026BB0
+SET_DATA gDefenderSkillBuffer, 0x02026C00
 SET_DATA gGenericSkillBuffer, 0x03003770
-SET_DATA gTempSkillBuffer, 0x03003780
+SET_DATA gTempSkillBuffer, 0x02026B90
 SET_DATA gAuraSkillBuffer, 0x02027200
 SET_DATA gUnitRangeBuffer, 0x0202764C
 SET_DATA pExtraItemOrSkill, 0x0202BCDE


### PR DESCRIPTION
- Adds a `isLocked` bool in skill buffers to tell `SkillTester` not call `MakeSkillBuffer` during weapon skill checks.
  - This prevents infinite recursion and, as a result, removes the need for `CheckSkillBuffer`.
- Fixes aura skills not working when attached to weapons equipped because of a weapon usability skill, such as Shadowgift.
- Handles more edge cases regarding weapon usability skill checks.